### PR TITLE
Add support for Promoted Build names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,11 +116,16 @@
 			<version>1.3.2</version>
 			<optional>true</optional>
 		</dependency>
+		<!--<dependency>-->
+			<!--<groupId>org.jenkins-ci.plugins</groupId>-->
+			<!--<artifactId>docker-commons</artifactId>-->
+			<!--<version>1.5</version>-->
+			<!--<optional>true</optional>-->
+		<!--</dependency>-->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>docker-commons</artifactId>
-			<version>1.5</version>
-			<optional>true</optional>
+			<artifactId>promoted-builds</artifactId>
+			<version>2.27</version>
 		</dependency>
         <dependency>
         	<groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,12 @@
 			<version>1.3.2</version>
 			<optional>true</optional>
 		</dependency>
-		<!--<dependency>-->
-			<!--<groupId>org.jenkins-ci.plugins</groupId>-->
-			<!--<artifactId>docker-commons</artifactId>-->
-			<!--<version>1.5</version>-->
-			<!--<optional>true</optional>-->
-		<!--</dependency>-->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>docker-commons</artifactId>
+			<version>1.5</version>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>promoted-builds</artifactId>

--- a/src/main/java/configurationslicing/docker/AbstractDockerSlicerSpec.java
+++ b/src/main/java/configurationslicing/docker/AbstractDockerSlicerSpec.java
@@ -41,6 +41,7 @@ public abstract class AbstractDockerSlicerSpec
         return item.getDisplayName();
     }
 
+    @Override
     public List<AbstractProject<?, ?>> getWorkDomain() {
         List<AbstractProject<?, ?>> filteredProjects = new ArrayList<AbstractProject<?, ?>>();
         List<AbstractProject> allProjects = Jenkins.getInstance().getAllItems(AbstractProject.class);

--- a/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
+++ b/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
@@ -39,7 +39,7 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
 
         // This sliced field has no default value
         @Override
-        public String getDefaultValueString() { return ""; }
+        public String getDefaultValueString() { return NOTHING; }
 
         @Override
         public String getName(AbstractProject<?,?> item) { return item.getFullName(); }
@@ -64,7 +64,7 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
 
             List<String> valuesList = new ArrayList<String>();
 
-            if (property != null) {
+            if (property != null && !property.getActiveItems().isEmpty()) {
                 String nameString = "";
                 for(PromotionProcess process : property.getActiveItems()) {
                     nameString = (String.format("%s[%s] ", nameString, process.getName()));
@@ -92,7 +92,7 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
                 }
             }
 
-            if(rawValues.get(0).equals(NOTHING)) {
+            if(rawValues.get(0).equals(NOTHING) && property != null) {
                 property.getActiveItems().removeAll(property.getActiveItems());
             }
 
@@ -128,8 +128,8 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
 
             List<String> values = new ArrayList<String>();
 
-            Pattern regex = Pattern.compile("\\[(.*?)\\]");
-            Matcher regexMatcher = regex.matcher(rawValues.get(0).replace(" ", ""));
+            Pattern stringInSquareBrackets = Pattern.compile("\\[(.*?)\\]");
+            Matcher regexMatcher = stringInSquareBrackets.matcher(rawValues.get(0).replace(" ", ""));
             while (regexMatcher.find()) {
                 values.add(regexMatcher.group(1));
             }

--- a/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
+++ b/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
@@ -85,15 +85,20 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
 
             List<String> values = parseValues(rawValues);
 
-            if (property == null && !values.isEmpty()) {
-                property = tryCreateProperty(item);
-                if (property == null) {
-                    return false;
+            if (property == null) {
+                if (!values.isEmpty()) {
+                    property = tryCreateProperty(item);
+                    if (property == null) {
+                        return false;
+                    }
+                } else {
+                    return true;
                 }
             }
 
             if(rawValues.get(0).equals(NOTHING) && property != null) {
                 property.getActiveItems().removeAll(property.getActiveItems());
+                return true;
             }
 
             Map<String, PromotionProcess> oldPromotions = new HashMap<String, PromotionProcess>();

--- a/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
+++ b/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
@@ -37,6 +37,7 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
         @Override
         public String getUrl() { return "promotedbuilds"; }
 
+        // This sliced field has no default value
         @Override
         public String getDefaultValueString() { return ""; }
 
@@ -64,11 +65,11 @@ public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProj
             List<String> valuesList = new ArrayList<String>();
 
             if (property != null) {
-                String del = "";
+                String nameString = "";
                 for(PromotionProcess process : property.getActiveItems()) {
-                    del = (String.format("%s[%s] ", del, process.getName()));
+                    nameString = (String.format("%s[%s] ", nameString, process.getName()));
                 }
-                valuesList.add(del.trim());
+                valuesList.add(nameString.trim());
             }
             if (valuesList.isEmpty() || valuesList.get(0).equals("")) {
                 valuesList.add(NOTHING);

--- a/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
+++ b/src/main/java/configurationslicing/promotedbuilds/PromotedBuildsNameSlicer.java
@@ -1,0 +1,155 @@
+package configurationslicing.promotedbuilds;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Throwables;
+import configurationslicing.UnorderedStringSlicer;
+import hudson.Extension;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractProject;
+import hudson.model.Project;
+import hudson.plugins.promoted_builds.JobPropertyImpl;
+import hudson.plugins.promoted_builds.PromotionProcess;
+import jenkins.model.Jenkins;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Extension
+public class PromotedBuildsNameSlicer extends UnorderedStringSlicer<AbstractProject<?,?>> {
+
+
+    public PromotedBuildsNameSlicer() {super(new PromotedBuildsSlicerSpec()); }
+
+    public static class PromotedBuildsSlicerSpec extends UnorderedStringSlicerSpec<AbstractProject<?,?>> {
+
+        private static final Logger log = LoggerFactory.getLogger(PromotedBuildsSlicerSpec.class);
+        public static final String NOTHING = "(NOTHING)";
+
+        @Override
+        public String getName() { return "Promoted Builds Names"; }
+
+        @Override
+        public String getUrl() { return "promotedbuilds"; }
+
+        @Override
+        public String getDefaultValueString() { return ""; }
+
+        @Override
+        public String getName(AbstractProject<?,?> item) { return item.getFullName(); }
+
+        @Override
+        public List<AbstractProject<?,?>> getWorkDomain() {
+            List<AbstractProject<?,?>> filteredProjects = new ArrayList<AbstractProject<?,?>>();
+            List<AbstractProject> allProjects = Jenkins.getInstance().getAllItems(AbstractProject.class);
+
+            for (AbstractProject project: allProjects) {
+                if (project instanceof Project || project instanceof MatrixProject) {
+                    filteredProjects.add(project);
+                }
+            }
+            return filteredProjects;
+        }
+
+        @Override
+        public List<String> getValues(AbstractProject<?,?> item) {
+
+            JobPropertyImpl property = item.getProperty(JobPropertyImpl.class);
+
+            List<String> valuesList = new ArrayList<String>();
+
+            if (property != null) {
+                String del = "";
+                for(PromotionProcess process : property.getActiveItems()) {
+                    del = (String.format("%s[%s] ", del, process.getName()));
+                }
+                valuesList.add(del.trim());
+            }
+            if (valuesList.isEmpty() || valuesList.get(0).equals("")) {
+                valuesList.add(NOTHING);
+            }
+
+            return valuesList;
+        }
+
+        @Override
+        public boolean setValues(AbstractProject<?,?> item, List<String> rawValues) {
+
+            JobPropertyImpl property = item.getProperty(JobPropertyImpl.class);
+
+            List<String> values = parseValues(rawValues);
+
+            if (property == null && !values.isEmpty()) {
+                property = tryCreateProperty(item);
+                if (property == null) {
+                    return false;
+                }
+            }
+
+            if(rawValues.get(0).equals(NOTHING)) {
+                property.getActiveItems().removeAll(property.getActiveItems());
+            }
+
+            Map<String, PromotionProcess> oldPromotions = new HashMap<String, PromotionProcess>();
+            for(PromotionProcess promotionProcess : property.getActiveItems()) {
+                oldPromotions.put(promotionProcess.getName(), promotionProcess);
+            }
+
+            // Remove old promotions
+            for(String oldName : oldPromotions.keySet()) {
+                if(!values.contains(oldName)) {
+                    property.getActiveItems().remove(oldPromotions.get(oldName));
+                }
+            }
+
+            // Add new promotions
+            for(String newName : values) {
+                if(!oldPromotions.keySet().contains(newName)) {
+                    try {
+                        property.addProcess(newName);
+                    } catch (IOException e) {
+                        log.error("Failed to add promotion process {} to project {}", newName, item.getName());
+                        Throwables.propagate(e);
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private List<String> parseValues(List<String> rawValues) {
+
+            List<String> values = new ArrayList<String>();
+
+            Pattern regex = Pattern.compile("\\[(.*?)\\]");
+            Matcher regexMatcher = regex.matcher(rawValues.get(0).replace(" ", ""));
+            while (regexMatcher.find()) {
+                values.add(regexMatcher.group(1));
+            }
+
+            return values;
+        }
+
+        private JobPropertyImpl tryCreateProperty(AbstractProject<?,?> item) {
+            log.info("Trying to set values on project {} where there is no property", item.getName());
+            try {
+                item.addProperty(new JobPropertyImpl(item));
+                JobPropertyImpl property = item.getProperty(JobPropertyImpl.class);
+                log.info("Successfully created property");
+                return property;
+            } catch (Exception e) {
+                log.error("Failed to create new property for project {}", item.getName());
+                Throwables.propagate(e);
+                return null;
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/configurationslicing/PromotedBuildNameSlicerTest.java
+++ b/src/test/java/configurationslicing/PromotedBuildNameSlicerTest.java
@@ -32,7 +32,6 @@ public class PromotedBuildNameSlicerTest extends HudsonTestCase {
         assert(spec.getValues(project).equals(Lists.newArrayList(spec.NOTHING)));
 
         assert(spec.setValues(project, rawValueListOne));
-        System.out.println(project.getProperty(JobPropertyImpl.class).getActiveItems().get(0).getName());
 
         List<String> values = spec.getValues(project);
         assert(values.get(0).equals(rawValueStringOne));

--- a/src/test/java/configurationslicing/PromotedBuildNameSlicerTest.java
+++ b/src/test/java/configurationslicing/PromotedBuildNameSlicerTest.java
@@ -1,0 +1,95 @@
+package configurationslicing;
+
+import com.google.common.collect.Lists;
+import configurationslicing.promotedbuilds.PromotedBuildsNameSlicer.PromotedBuildsSlicerSpec;
+import hudson.model.AbstractProject;
+import hudson.model.Project;
+import hudson.plugins.promoted_builds.JobPropertyImpl;
+import hudson.plugins.promoted_builds.PromotionProcess;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.List;
+
+public class PromotedBuildNameSlicerTest extends HudsonTestCase {
+
+    private String expectedPromotionOne = "promotionOne";
+    private String expectedPromotionTwo = "promotionTwo";
+
+    private String rawValueStringOne = String.format("[%s]", expectedPromotionOne);
+    private String rawValueStringTwo = String.format("[%s]", expectedPromotionTwo);
+    private String rawValueStringMultiple = String.format("[%s] [%s]", expectedPromotionOne, expectedPromotionTwo);
+
+    private List<String> rawValueListOne = Lists.newArrayList(rawValueStringOne);
+    private List<String> rawValueListTwo = Lists.newArrayList(rawValueStringTwo);
+    private List<String> rawValueListMultiple = Lists.newArrayList(rawValueStringMultiple);
+
+
+
+    public void testAddNewPromotionProcessToProjectWithNoProperty() throws Exception {
+        PromotedBuildsSlicerSpec spec = new PromotedBuildsSlicerSpec();
+        AbstractProject<?,?> project = createUnpopulatedProject();
+
+        assert(spec.getValues(project).equals(Lists.newArrayList(spec.NOTHING)));
+
+        assert(spec.setValues(project, rawValueListOne));
+        System.out.println(project.getProperty(JobPropertyImpl.class).getActiveItems().get(0).getName());
+
+        List<String> values = spec.getValues(project);
+        assert(values.get(0).equals(rawValueStringOne));
+
+        List<PromotionProcess> promotionProcesses = project.getProperty(JobPropertyImpl.class).getActiveItems();
+        assert(promotionProcesses.size() == 1);
+        assert(promotionProcesses.get(0).getName().equals(expectedPromotionOne));
+    }
+
+    public void testAddNewPromotionProcessToPopulatedProjectProperty() throws Exception {
+        PromotedBuildsSlicerSpec spec = new PromotedBuildsSlicerSpec();
+        AbstractProject<?,?> project = createPopulatedProject();
+
+        project.getProperty(JobPropertyImpl.class).addProcess(expectedPromotionOne);
+
+        assert(spec.getValues(project).equals(rawValueListOne));
+
+        assert(spec.setValues(project, rawValueListMultiple));
+
+        List<String> values = spec.getValues(project);
+        assert(values.get(0).equals(rawValueStringMultiple));
+
+        List<PromotionProcess> promotionProcesses = project.getProperty(JobPropertyImpl.class).getActiveItems();
+        assert(promotionProcesses.size() == 2);
+        assert(promotionProcesses.get(0).getName().equals(expectedPromotionOne));
+        assert(promotionProcesses.get(1).getName().equals(expectedPromotionTwo));
+
+    }
+
+    public void testRemovePromotionProcessFromPopulatedProjectProperty() throws Exception {
+        PromotedBuildsSlicerSpec spec = new PromotedBuildsSlicerSpec();
+        AbstractProject<?,?> project = createPopulatedProject();
+
+        project.getProperty(JobPropertyImpl.class).addProcess(expectedPromotionOne);
+        project.getProperty(JobPropertyImpl.class).addProcess(expectedPromotionTwo);
+
+        assert(spec.getValues(project).equals(rawValueListMultiple));
+
+        assert(spec.setValues(project, rawValueListTwo));
+
+        List<String> values = spec.getValues(project);
+        assert(values.get(0).equals(rawValueStringTwo));
+
+        List<PromotionProcess> promotionProcesses = project.getProperty(JobPropertyImpl.class).getActiveItems();
+        assert(promotionProcesses.size() == 1);
+        assert(promotionProcesses.get(0).getName().equals(expectedPromotionTwo));
+
+    }
+
+    private Project createPopulatedProject() throws Exception {
+        Project project = createFreeStyleProject();
+        project.addProperty(new JobPropertyImpl(project));
+
+        return project;
+    }
+
+    private Project createUnpopulatedProject() throws Exception {
+        return createFreeStyleProject();
+    }
+}


### PR DESCRIPTION
Allows the slicing of promoted build names. Promotion names must be wrapped in
square brackets as a design decision to be able to handle when a promotion
is removed from a project.